### PR TITLE
Update post process according to common implementation practices

### DIFF
--- a/Assets/IndirectDraw.cs
+++ b/Assets/IndirectDraw.cs
@@ -6,7 +6,7 @@ using YoloV4Tiny;
 public sealed class IndirectDraw : MonoBehaviour
 {
     [SerializeField] ImageSource _source = null;
-    [SerializeField, Range(0, 1)] float _threshold = 0.5f;
+    [SerializeField, Range(0, 1)] float _confidenceThreshold = 0.5f;
     [SerializeField] ResourceSet _resources = null;
     [SerializeField] RawImage _preview = null;
     [SerializeField] Shader _shader = null;
@@ -34,7 +34,7 @@ public sealed class IndirectDraw : MonoBehaviour
 
     void LateUpdate()
     {
-        _detector.ProcessImage(_source.Texture, _threshold);
+        _detector.ProcessImage(_source.Texture, _confidenceThreshold);
         _detector.SetIndirectDrawCount(_drawArgs);
         _material.SetBuffer("_Detections", _detector.DetectionBuffer);
         Graphics.DrawProceduralIndirect(_material, UnitBox, MeshTopology.Triangles, _drawArgs);

--- a/Assets/Visualizer.cs
+++ b/Assets/Visualizer.cs
@@ -8,7 +8,7 @@ sealed class Visualizer : MonoBehaviour
     #region Editable attributes
 
     [SerializeField] ImageSource _source = null;
-    [SerializeField, Range(0, 1)] float _threshold = 0.5f;
+    [SerializeField, Range(0, 1)] float _confidenceThreshold = 0.5f;
     [SerializeField] ResourceSet _resources = null;
     [SerializeField] RawImage _preview = null;
     [SerializeField] Marker _markerPrefab = null;
@@ -41,7 +41,7 @@ sealed class Visualizer : MonoBehaviour
 
     void Update()
     {
-        _detector.ProcessImage(_source.Texture, _threshold);
+        _detector.ProcessImage(_source.Texture, _confidenceThreshold);
 
         var i = 0;
         foreach (var d in _detector.Detections)

--- a/Packages/jp.keijiro.yolov4tiny/Shader/Postprocess1.compute
+++ b/Packages/jp.keijiro.yolov4tiny/Shader/Postprocess1.compute
@@ -9,7 +9,7 @@ Texture2D<float> Input;
 uint InputSize;
 float2 Anchors[ANCHOR_COUNT];
 uint ClassCount;
-float Threshold;
+float ConfidenceThreshold;
 
 // Output buffer
 RWStructuredBuffer<Detection> Output;
@@ -33,21 +33,19 @@ void Postprocess1(uint2 id : SV_DispatchThreadID)
         float y = Input[uint2(ref_x + 1, ref_y)];
         float w = Input[uint2(ref_x + 2, ref_y)];
         float h = Input[uint2(ref_x + 3, ref_y)];
-        float c = Input[uint2(ref_x + 4, ref_y)];
+        float boxConfidence = Input[uint2(ref_x + 4, ref_y)];
+        float classProbs = Input[uint2(ref_x + 5, ref_y)];
 
-        // ArgMax[SoftMax[classes]]
+        // Calc classProbs & maxClass
         uint maxClass = 0;
-        float maxScore = exp(Input[uint2(ref_x + 5, ref_y)]);
-        float scoreSum = maxScore;
         for (uint cidx = 1; cidx < ClassCount; cidx++)
         {
-            float score = exp(Input[uint2(ref_x + 5 + cidx, ref_y)]);
-            if (score > maxScore)
+            float classProbsTemp = Input[uint2(ref_x + 5 + cidx, ref_y)];
+            if (classProbsTemp > classProbs)
             {
+                classProbs = classProbsTemp;
                 maxClass = cidx;
-                maxScore = score;
             }
-            scoreSum += score;
         }
 
         // Output structure
@@ -57,14 +55,17 @@ void Postprocess1(uint2 id : SV_DispatchThreadID)
         data.w = exp(w) * Anchors[aidx].x;
         data.h = exp(h) * Anchors[aidx].y;
         data.classIndex = maxClass;
-        data.score = Sigmoid(c) * maxScore / scoreSum;
+        data.score = Sigmoid(boxConfidence) * Sigmoid(classProbs);
 
         // Thresholding
-        if (data.score > Threshold)
+        if (data.score > ConfidenceThreshold)
         {
             // Detected: Count and output
             uint count = OutputCount.IncrementCounter();
-            if (count < MAX_DETECTION) Output[count] = data;
+            if (count < MAX_DETECTION)
+            {
+                Output[count] = data;
+            }
         }
     }
 }

--- a/Packages/jp.keijiro.yolov4tiny/Shader/Postprocess2.compute
+++ b/Packages/jp.keijiro.yolov4tiny/Shader/Postprocess2.compute
@@ -7,7 +7,8 @@
 // Input
 StructuredBuffer<Detection> Input;
 RWStructuredBuffer<uint> InputCount; // Only used as a counter
-float Threshold;
+float IouThreshold;
+uint ClassCount;
 
 // Output
 AppendStructuredBuffer<Detection> Output;
@@ -23,39 +24,55 @@ void Postprocess2(uint3 id : SV_DispatchThreadID)
     uint entry_count = min(MAX_DETECTION, InputCount.IncrementCounter());
     if (entry_count == 0) return;
 
-    for (uint i = 0; i < entry_count; i++)
+    // Apply for each class
+    for (uint c = 0; c < ClassCount; c++)
     {
-        _entries[i] = Input[i];
-        _flags[i] = true;
-    }
-
-    // Overlap test permutation
-    for (i = 0; i < entry_count - 1; i++)
-    {
-        if (!_flags[i]) continue;
-
-        for (uint j = i + 1; j < entry_count; j++)
+        // Separate detections by class
+        uint count = 0;
+        for (uint i = 0; i < entry_count; i++)
         {
-            if (!_flags[j]) continue;
+            if (Input[i].classIndex != c) continue;
 
-            // Overlap test
-            if (CalculateIOU(_entries[i], _entries[j]) < Threshold)
-                continue;
-
-            // Score comparison
-            if (_entries[i].score < _entries[j].score)
-            {
-                _flags[i] = false;
-                // The detection in the outer loop is removed.
-                // Break the inner loop.
-                break;
-            }
-            else
-                _flags[j] = false;
+            // Store the detection in the cache arrays
+            _entries[count] = Input[i];
+            _flags[count] = true;
+            count++;
         }
-    }
 
-    // Output aggregation
-    for (i = 0; i < entry_count; i++)
-        if (_flags[i]) Output.Append(_entries[i]);
+        if (count == 0) continue;
+
+        // Sort detections by score
+        for (i = 0; i < count - 1; i++)
+        {
+            for (uint j = i + 1; j < count; j++)
+            {
+                // Score comparison
+                if (_entries[i].score < _entries[j].score)
+                {
+                    Detection temp = _entries[i];
+                    _entries[i] = _entries[j];
+                    _entries[j] = temp;
+                }
+            }
+        }
+
+        // Overlap test permutation
+        for (i = 0; i < count - 1; i++)
+        {
+            if (!_flags[i]) continue;
+
+            for (uint j = i + 1; j < count; j++)
+            {
+                if (!_flags[j]) continue;
+
+                // Overlap test
+                if (CalculateIOU(_entries[i], _entries[j]) > IouThreshold)
+                    _flags[j] = false;
+            }
+        }
+
+        // Output aggregation
+        for (i = 0; i < count; i++)
+            if (_flags[i]) Output.Append(_entries[i]);
+    }
 }


### PR DESCRIPTION
This pull request asks for an implementation fix for Issue: #11.   
Implementing additional features (Soft-NMS) will be a separate pull request.

# Achievement of conditions
- The score calculation is updated to compute the confidence score for each bounding box as the product of the box confidence score and the class confidence score, applying a sigmoid function to each.
- NMS is applied independently for each class to prevent accidental deletion of objects of different classes.

# Implementation details
- I modify the score calculation logic so that the confidence score for each bounding box is calculated as the product of the objectness score and the score of the highest-scoring class. Both scores are normalized using a sigmoid function. This approach follows the assumption that each bounding box belongs to only one class.
- Change the implementation to apply NMS to each class individually.
- Sort the detections based on their scores before applying NMS.
- For each fix change the variable name to something appropriate.

# Concern
- The current implementation assumes that each bounding box belongs to only that one class. On the other hand, the keras implementation of YOLOv4Tiny referenced in this repository takes into account the case where each bounding box belongs to multiple classes.
- While the implementation of per-class NMS is a standard practice in object detection models, it might lead to an increase in computational complexity, especially when dealing with a large number of classes. This could potentially impact the performance of the model.

# Remaining issues
In the future, I think it should be improved to account for the possibility that each bounding box belongs to multiple classes. 